### PR TITLE
Version 3.3.1

### DIFF
--- a/certsage.php
+++ b/certsage.php
@@ -15,7 +15,7 @@ Usage of this software constitutes acceptance of full liability for any conseque
 namespace CertSage;
 use Exception;
 
-$version = "3.2.1";
+$version = "3.3.1";
 $dataDirectory = "../CertSage";
 
 function createDirectory($directory)
@@ -586,6 +586,8 @@ function acquireCertificate($environment)
     if ($order["status"] !== "valid")
       throw new Exception("order failed");
   }
+
+  sleep(2); // delay for downloading certificate
 
   $url = $order["certificate"];
 


### PR DESCRIPTION
* Added a delay before downloading certificate to address errors coming from Let's Encrypt server caused by requesting certificate download too soon after completion of order finalization